### PR TITLE
重庆话中lü只有上声

### DIFF
--- a/shupin_congqin.schema.yaml
+++ b/shupin_congqin.schema.yaml
@@ -103,6 +103,8 @@ speller:
 #泥來部分
     - xform/^ni/li/	#啓用此行表示ni, ni->li, li-
     - xform/^nv/lv/
+    - xform/^lv2/lu2/
+    - xform/^lv4/lui4/
 #    - xform/^ni/y/	#啓用此行表示ni->y-
 #    - xform/^ni([12345])$/yi$1/	#啓用此行表示ni>yi
 


### PR DESCRIPTION
lü只有上声可从知乎文章 https://zhuanlan.zhihu.com/p/79034026 得到佐证，其中对该音节列出的声调与例字如下：
lǜ　旅吕　(nǜ) 女

对于阳平和去声，分别派入其他音（未经考证，仅凭我的用法）
lü̂ (lv2) -> lû (lu2)，如：律(lu2)师，黔驴(lu2)技穷
lǘ (lv4) -> luí (lui4)，如：过滤(lui4)，考虑(lui4)